### PR TITLE
Fixing the replacement of ':' with '__' for features

### DIFF
--- a/Model/shared_scripts/DataProcess.py
+++ b/Model/shared_scripts/DataProcess.py
@@ -114,7 +114,7 @@ def DataProcess(test_year, frequency, modelname, Region_list, fSCA = False):
         df = df[optfeatures]
 
         ### replace special character ':' with '__' 
-        df = df.rename(columns = lambda x:re.sub(':', '__', x))
+        # df = df.rename(columns = lambda x:re.sub(':', '__', x))
 
         #change all na values to prevent scaling issues
         df[df< -9000]= -10    


### PR DESCRIPTION
During data scaling, the special character ':' was being replaced with '__' for the features and that was producing "ValueError". So, I modified the code to stop the replacement.